### PR TITLE
enhancement: Remove custom 'b' keybind from comments page

### DIFF
--- a/components/comments/commentsPage.go
+++ b/components/comments/commentsPage.go
@@ -73,7 +73,7 @@ func (c CommentsPage) handleFocusedMessages(msg tea.Msg) (CommentsPage, tea.Cmd)
 		case "H":
 			return c, messages.LoadHome
 
-		case "b", "B", "escape", "backspace", "left", "h":
+		case "B", "escape", "backspace", "left", "h":
 			return c, messages.GoBack
 
 		case "o", "O":


### PR DESCRIPTION
The [viewport bubbletea component](https://github.com/charmbracelet/bubbles/blob/master/viewport/keymap.go) maps `b` to `PageUp`, similar to `<Ctrl+b>` in Vim. As reddit-tui mostly sticks to vim-like keybinds and even uses `b` for `PageUp` on the posts page, it seems to make sense to streamline this.