### PR TITLE
chore: update README to mention AUR -bin package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ cd reddittui
 ```
 
 ### Arch
-Arch users can install reddittui from the [AUR](https://aur.archlinux.org/packages/reddit-tui) using yay or other AUR helpers:
+Arch users can install reddittui from the AUR using yay or other AUR helpers.
+
+[Pre-compiled](https://aur.archlinux.org/packages/reddit-tui-bin) and [source packages](https://aur.archlinux.org/packages/reddit-tui) are available.
 
 ```bash
-yay reddit-tui
+yay -S reddit-tui-bin
+```
+
+```bash
+yay -S reddit-tui
 ```
 
 ### Nix


### PR DESCRIPTION
I just submitted a binary version of the reddi-tui package to the AUR for users who prefer faster installation over the benefits of building from source.

This updates the README to mention both packages.